### PR TITLE
Modernise Python syntax. 

### DIFF
--- a/mustard/rawtree.py
+++ b/mustard/rawtree.py
@@ -52,7 +52,7 @@ class Tree(object):
             try:
                 data = load_yaml(io, filename.replace('.yaml', ''))
                 self._insert_raw(filename.replace('.yaml', ''), data)
-            except Exception, error:
+            except Exception as error:
                 errors.append(error)
         if errors:
             raise LoadError(errors)

--- a/mustard/renderer.py
+++ b/mustard/renderer.py
@@ -130,9 +130,9 @@ class App(cliapp.Application):
                     self.content[content_id] = bottle.template(
                         view, tree=element_tree)
                 return self.content[content_id]
-        except mustard.MustardError, err:
+        except mustard.MustardError as err:
             return bottle.template('treeerror', error=err)
-        except cliapp.AppException, err:
+        except cliapp.AppException as err:
             return bottle.template('error', error=err)
 
     def render_diff(self, state1, state2, view):
@@ -163,9 +163,9 @@ class App(cliapp.Application):
                     self.content[content_id] = bottle.template(
                         'diff', tree=tree1, other_tree=tree2)
                 else:
-                    print 'using cached rendering of (%s, %s, %s)' % content_id
+                    print ('using cached rendering of (%s, %s, %s)' % content_id)
                 return self.content[content_id]
-        except cliapp.AppException, err:
+        except cliapp.AppException as err:
             return bottle.template('error', error=err)
 
     def render_export(self, stateid, view, forms=None):
@@ -181,7 +181,7 @@ class App(cliapp.Application):
             return bottle.template(
                 view, tree=element_tree, forms=forms,
                 elements=mustard.elementfactory.element_descriptions)
-        except cliapp.AppException, err:
+        except cliapp.AppException as err:
             return bottle.template('error', error=err)
 
     def process_args(self, args):
@@ -207,12 +207,12 @@ class App(cliapp.Application):
         base_url = self.settings['base-url']
         self.base_url = base_url
 
-        print 'base url: %s' % self.base_url
+        print ('base url: %s' % self.base_url)
 
         @route('/')
         @self.auth.protected
         def index():
-            print 'redirect to %s' % os.path.join(self.base_url, '/HEAD')
+            print ('redirect to %s' % os.path.join(self.base_url, '/HEAD'))
             return bottle.redirect(os.path.join(self.base_url, '/HEAD'))
 
         @route('/favicon.ico')
@@ -334,7 +334,7 @@ class App(cliapp.Application):
                 bottle.response.set_header('Content-Encoding', encoding)
 
                 return self.content[content_id]
-            except Exception, err:
+            except Exception as err:
                 bottle.response.status = 404
                 return bottle.template('error', error=err)
 

--- a/mustard/repository.py
+++ b/mustard/repository.py
@@ -90,7 +90,7 @@ class Repository(object):
         while queue:
             (tree, path) = queue.popleft()
             for entry in tree:
-                if entry.filemode == 040000:
+                if entry.filemode == 0o40000:
                     subtree = self.repo[entry.oid]
                     queue.append((subtree, os.path.join(path, entry.name)))
                 else:

--- a/mustard/state.py
+++ b/mustard/state.py
@@ -98,7 +98,7 @@ class CommittedState(State):
         self.identifier = ref
         self.sha1 = sha1
         self.url = os.path.join(app.base_url, self.identifier)
-        print 'committed state url: %s' % self.url
+        print ('committed state url: %s' % self.url)
 
         commit = self.repository.commit(self.sha1)
 
@@ -171,10 +171,10 @@ class Cache(object):
                        tuple(self.repository.branches()))
 
                 if not key in self.states:
-                    print '%s not in cache' % sha1
+                    print ('%s not in cache' % sha1)
                     self.states[key] = CommittedState(
                         self.app, self, self.repository, ref, sha1)
-                print '%s now cached' % sha1
+                print ('%s now cached' % sha1)
                 return self.states[key]
             except cliapp.AppException:
                 raise InvalidStateError(ref)

--- a/mustard/util.py
+++ b/mustard/util.py
@@ -19,12 +19,6 @@ import collections
 import yaml
 import yaml.constructor
 
-
-if not hasattr(collections, 'OrderedDict'):
-    import ordereddict
-    collections.OrderedDict = ordereddict.OrderedDict
-
-
 class OrderedDictYAMLLoader(yaml.cyaml.CLoader):
     """
     A YAML loader that loads mappings into ordered dictionaries.
@@ -56,7 +50,7 @@ class OrderedDictYAMLLoader(yaml.cyaml.CLoader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise yaml.constructor.ConstructorError(
                     'while constructing a mapping',
                     node.start_mark, 'found unacceptable key (%s)' %


### PR DESCRIPTION
This enables the type-checking tool mypy to work on Mustard without any errors.

Mypy dislikes the hack used to add OrderedDict for pre-2.7 Python so
I've removed that. It shouldn't be necessary on any modern system.