### PR TITLE
Add explicit sort order for display of sections in the HTML export

### DIFF
--- a/mustard/elementfactory.py
+++ b/mustard/elementfactory.py
@@ -79,6 +79,7 @@ element_descriptions = {
   'requirement': {
     'title-plural':   'Requirements',
     'title-singular': 'Requirement',
+    'sort-order': 1,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -91,6 +92,7 @@ element_descriptions = {
   'component': {
     'title-plural':   'Components',
     'title-singular': 'Component',
+    'sort-order': 2,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -113,6 +115,7 @@ element_descriptions = {
   'interface': {
     'title-plural':   'Interfaces',
     'title-singular': 'Interface',
+    'sort-order': 3,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -130,6 +133,7 @@ element_descriptions = {
   'work-item': {
     'title-plural':   'Work Items',
     'title-singular': 'Work Item',
+    'sort-order': 4,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -144,6 +148,7 @@ element_descriptions = {
   'tag': {
     'title-plural':   'Tags',
     'title-singular': 'Tag',
+    'sort-order': 5,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -153,6 +158,7 @@ element_descriptions = {
   'integration-strategy': {
     'title-plural':   'Integration Strategies',
     'title-singular': 'Integration Strategy',
+    'sort-order': 6,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },
@@ -169,6 +175,7 @@ element_descriptions = {
   'verification-criterion': {
     'title-plural':   'Verification Criteria',
     'title-singular': 'Verification Criterion',
+    'sort-order': 7,
     'default': True,
     'fields': [
       { 'name': 'description',  'title': 'Description',  'default': True  },

--- a/views/export-html.tpl
+++ b/views/export-html.tpl
@@ -21,7 +21,7 @@
       </div>
       <div id="nav">
         <ol>
-          % for field, info in sorted(elements.iteritems(), key=lambda x: x[1]['title-plural']):
+          % for field, info in sorted(elements.iteritems(), key=lambda x: x[1]['sort-order']):
             % if forms.get('select-%s' % field):
               % kind_elements = tree.find_all(kind=field, top_level=True)
               % if kind_elements:
@@ -35,7 +35,7 @@
         % index = [1]
         % level = 3
 
-        % for field, info in sorted(elements.iteritems(), key=lambda x: x[1]['title-plural']):
+        % for field, info in sorted(elements.iteritems(), key=lambda x: x[1]['sort-order']):
           % if forms.get('select-%s' % field):
             % kind_elements = tree.find_all(kind=field, sort_by='DEFAULT', top_level=True)
             % if kind_elements:


### PR DESCRIPTION
Current behaviour is to sort sections alphabetically for the HTML export, so "components" comes before "requirements", which doesn't really make sense.