### PR TITLE
Correct path for os.path.join so base_url will work correctly.

### DIFF
--- a/mustard/renderer.py
+++ b/mustard/renderer.py
@@ -216,8 +216,8 @@ class App(cliapp.Application):
         @route('/')
         @self.auth.protected
         def index():
-            print ('redirect to %s' % os.path.join(self.base_url, '/HEAD'))
-            return bottle.redirect(os.path.join(self.base_url, '/HEAD'))
+            print ('redirect to %s' % os.path.join(self.base_url, 'HEAD'))
+            return bottle.redirect(os.path.join(self.base_url, 'HEAD'))
 
         @route('/favicon.ico')
         def favicon():


### PR DESCRIPTION
If the second argument to os.path.join (and urljoin, as we should be using)
starts with a slash, it ignores all of the first argument - so before this
change, base_url would always be ignored.